### PR TITLE
Update to binwrap-0.2.0-rc2

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ var root =
   version;
 
 module.exports = binwrap({
+  dirname: __dirname,
   binaries: ["elmi-to-json"],
   urls: {
     "darwin-x64": root + "-osx.tar.gz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "elmi-to-json",
-  "version": "0.19.0",
+  "version": "0.19.0-rc2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -64,9 +64,9 @@
       }
     },
     "binwrap": {
-      "version": "0.2.0-rc1",
-      "resolved": "https://registry.npmjs.org/binwrap/-/binwrap-0.2.0-rc1.tgz",
-      "integrity": "sha512-Rzv4oC1o7lEPnOuA7TrKN8K7PO8blBWlUk1HOTFn6rDM1TQzYRgELwk/AkqkphVNOKnqgWrODWDUI5D8gElzPA==",
+      "version": "0.2.0-rc2",
+      "resolved": "https://registry.npmjs.org/binwrap/-/binwrap-0.2.0-rc2.tgz",
+      "integrity": "sha512-X4Oe1g4fatWm3UbWE7lxa6Zz9XA1IT0JsOUpszFzeQUGSsDiFoZydKHQ3YQt4RcETOh7N5tV691CSzxOoBGMew==",
       "requires": {
         "mustache": "2.3.0",
         "request": "2.87.0",
@@ -258,7 +258,7 @@
       "requires": {
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
-        "sshpk": "1.14.1"
+        "sshpk": "1.14.2"
       }
     },
     "inflight": {
@@ -453,10 +453,15 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "sshpk": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
-      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "requires": {
         "asn1": "0.2.3",
         "assert-plus": "1.0.0",
@@ -465,6 +470,7 @@
         "ecc-jsbn": "0.1.1",
         "getpass": "0.1.7",
         "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
         "tweetnacl": "0.14.5"
       }
     },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   },
   "homepage": "https://github.com/stoeffel/elmi-to-json#readme",
   "dependencies": {
-    "binwrap": "^0.2.0-rc1"
+    "binwrap": "^0.2.0-rc2"
   }
 }


### PR DESCRIPTION
binwrap-0.2.0-rc2 adds a feature that exposes the resolved path of the wrapped binaries (which is necessary for elm-test to be able to find them, as npm can install packages in many different places!)