### PR TITLE
Support alternate locales on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
 - |
   if [ "$TRAVIS_OS_NAME" = linux ]; then
     echo "Compiling static binary"
-    stack build --ghc-options -O2 --flag="elmi-to-json:static"
+    stack build --ghc-options "-O2 -fPIC" --flag="elmi-to-json:static"
   else
     echo "Compiling dynamic binary"
     stack build --ghc-options -O2


### PR DESCRIPTION
The new statically linked binary crashed when using different locales to
the one compiled with.

I think this may solve the problem @michaelerne reported. It worked in my testing but I want to verify it works on Michael's machine using a binary build on travis