### PR TITLE
Use xenial on Travis to fix static build (#23)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,11 @@ env:
   - CASHER_TIME_OUT=1000
   - BUILD="elmi-to-json-${TRAVIS_TAG}-${TRAVIS_OS_NAME}.tar.gz"
 language: c
-os:
-- linux
-- osx
+matrix:
+  include:
+    - os: linux
+      dist: xenial
+    - os: osx
 sudo: false
 script:
 - stack setup


### PR DESCRIPTION
This is how hadolint fixed a similar issue:
* https://github.com/hadolint/hadolint/pull/214

I also tried the `LC_ALL=` [approach](https://github.com/hadolint/hadolint/pull/211), but it didn't work. I tested this on [my fork](https://github.com/bowsersenior/elmi-to-json/releases/tag/untagged-faa39278e2ce34998841) using this Dockerfile:

```
FROM ubuntu:18.10
# ADD https://github.com/stoeffel/elmi-to-json/releases/download/0.19.2-rc/elmi-to-json-0.19.2-rc-linux.tar.gz /
ADD https://github.com/bowsersenior/elmi-to-json/releases/download/untagged-faa39278e2ce34998841/elmi-to-json--linux.tar.gz /

RUN mkdir -p /usr/local/bin \
 && tar -C /usr/local/bin -xzf /elmi-to-json*.tar.gz \
 && rm -f /elmi-to-json*.tar.gz

RUN apt-get update \
 && apt-get install -y language-pack-en \
 && rm -rf /var/lib/apt/lists/*
```

And running the following commands:
```bash
$ docker build -t elmi-to-json:latest .
...

$ docker run --rm -ti elmi-to-json bash -c "LC_CTYPE=en_GB.UTF-8 elmi-to-json --help"
elmi-to-json - Convert the interface info into json.

Usage: elmi-to-json [MODULE_PATHS] [-o|--output ARG]
  Get info for specific modules.

Available options:
  -h,--help                Show this help text
  MODULE_PATHS             Get info for specific modules.
  -o,--output ARG          Output info to a file.
```