### PR TITLE
update to stackage13.25

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -32,16 +32,16 @@ library:
   - src
   - types-from-compiler
   dependencies:
-  - aeson
-  - async
-  - binary
-  - bytestring
-  - containers
-  - directory
-  - filepath
-  - optparse-applicative
-  - safe-exceptions
-  - text
+  - aeson == 1.4.*
+  - async == 2.2.*
+  - binary == 0.8.*
+  - bytestring == 0.10.*
+  - containers == 0.*
+  - directory == 1.3.*
+  - filepath == 1.4.*
+  - optparse-applicative == 0.14.*
+  - safe-exceptions == 0.1.*
+  - text == 1.2.*
   ghc-options:
   - -Wall
   - -Werror

--- a/package.yaml
+++ b/package.yaml
@@ -32,16 +32,16 @@ library:
   - src
   - types-from-compiler
   dependencies:
-  - aeson == 1.2.4.0
-  - async == 2.1.1.1
-  - binary == 0.8.5.1
-  - bytestring == 0.10.8.2
-  - containers == 0.5.10.2
-  - directory == 1.3.0.2
-  - filepath == 1.4.1.2
-  - optparse-applicative == 0.14.2.0
-  - safe-exceptions == 0.1.7.0
-  - text == 1.2.3.0
+  - aeson
+  - async
+  - binary
+  - bytestring
+  - containers
+  - directory
+  - filepath
+  - optparse-applicative
+  - safe-exceptions
+  - text
   ghc-options:
   - -Wall
   - -Werror

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-11.0
+resolver: lts-13.25
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
Hello :wave:

This PR aims to simplify the build without `stack`.

## Background

I'm working on the support of [elm tooling for nixos](https://github.com/turboMaCk/nix-elm-tools). Nix uses source-based package management and therefore building the source for elmi-to-json is more in line with nix philosophy than using statically linked binary blob.

- binary blob download [still works](https://github.com/turboMaCk/nix-elm-tools/blob/master/elmi-to-json.nix#L36-L59) but is not a preferable option in [nixpkgs](https://github.com/NixOS/nixpkgs) upstream
- [compilation from source](https://github.com/turboMaCk/nix-elm-tools/blob/master/elmi-to-json.nix#L11-L34) works as well but [requires patch](https://github.com/turboMaCk/nix-elm-tools/blob/master/patches/elmi-to-json.patch)

This project uses the stack as a default build tool which is fine and I don't want to change that. In fact, there is even [stack2nix](https://github.com/input-output-hk/stack2nix) project which can be used for fully compatible build on nix/nixos but there are some downsides.

## Stack vs Nix

I'm not really export on either Stack and nix but I think both do essentially the same thing. Both provide curated package set of Haskell packages which are known to compile together preventing so-called [cabal hell](https://wiki.haskell.org/Cabal/Survival).

- Stack uses a system of [resolvers](https://github.com/stoeffel/elmi-to-json/blob/master/stack.yaml#L18). Every resolver is essentially a snapshot of Hackage packages that are tested to work together.
- NixOS uses nixpkgs set containing Haskell libraries that are also known to work together.

The problem here is that even though the basic strategy is essentially the same, both snapshots are different and contain different versions of packages.

- Using stack2nix means compiling a large number of Haskell dependencies resulting in unnecessary slow builds.
- Because `package.yaml` contains exact versions of dependencies from stackage it's not compatible with nix which contains slightly different versions.

## Proposed Solution

This PR removes constraints to exact versions from `package.yaml`. I think this means that using `stack` it will still work as it is. Stack uses curated package versions from stackage anyway so the versions are essentially already specified by [resolver](https://github.com/stoeffel/elmi-to-json/blob/master/stack.yaml#L18). With nix, other versions (also compatible) would be used - the versions which are part of the nixpkgs set.

## Alternative Solution

If this PR won't be accepted we can still patch `package.yaml` - it's not that big deal. Anyway, I believe this is still unnecessary and It's a good practice to try to upstream changes that need to be patched in nixpkgs first.

I'm happy to provide any help and answer any questions. 

## Details

These are the specified versions of dependencies that are not in nixpkgs:

```
Setup: Encountered missing dependencies:
aeson ==1.2.4.0,
async ==2.1.1.1,
binary ==0.8.5.1,
containers ==0.5.10.2,
directory ==1.3.0.2,
filepath ==1.4.1.2,
optparse-applicative ==0.14.2.0,
text ==1.2.3.0
```