### PR TITLE
Added binwrap URL for FreeBSD x64 binary.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ module.exports = binwrap({
   binaries: ["elmi-to-json"],
   urls: {
     "darwin-x64": root + "-osx.tar.gz",
+    "freebsd-x64": root + "-freebsd.tar.gz",
     "linux-x64": root + "-linux.tar.gz",
     "win32-x64": root + "-win32-x64.zip",
     "win32-ia32": root + "-win32-ia32.zip"


### PR DESCRIPTION
Allows installation of elmi-to-json on FreeBSD using npm.  The attached executable was built using stack on FreeBSD 12.1-RELEASE-p6.
[elmi-to-json-1.3.0-freebsd.tar.gz](https://github.com/stoeffel/elmi-to-json/files/4837145/elmi-to-json-1.3.0-freebsd.tar.gz)
