### PR TITLE
Add Apple M1 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ module.exports = binwrap({
   binaries: ["elmi-to-json"],
   urls: {
     "darwin-x64": root + "-osx.tar.gz",
+    "darwin-arm64": root + "-osx.tar.gz", // Apple M1 chips support x64 emulation so we can re-use it for now
     "linux-x64": root + "-linux.tar.gz",
     "win32-x64": root + "-win32-x64.zip",
     "win32-ia32": root + "-win32-ia32.zip"


### PR DESCRIPTION
Fixes https://github.com/stoeffel/elmi-to-json/issues/39.

I have verified that this works locally on an M1 chip by using [npm-shrinkwrap](https://docs.npmjs.com/cli/v7/configuring-npm/npm-shrinkwrap-json) to override the dependency with my fork, and no longer get the missing binary error.

### Testing / temporary workaround

For testing, or anyone wanting to fix this issue before this gets resolved here, here's how you can apply this PR in the short term:

- Run `npm shrinkwrap` to get a copy of your `package-json.lock` that you can modify. This lets you arbitrarily override package sub-dependencies. See [docs](https://docs.npmjs.com/cli/v7/configuring-npm/npm-shrinkwrap-json) for more details.
- Find all version instances of `"elmi-to-json": "1.3.0",` and replace with URL i.e. `"elmi-to-json": "https://github.com/supermario/elmi-to-json",`
- Find all `"elmi-to-json": {` or `"node_modules/elmi-to-json": {` blocks and remove them entirely.
